### PR TITLE
Potential fix for code scanning alert no. 55: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -76,6 +76,8 @@ public class CommentsCache {
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 
     var unmarshaller = jc.createUnmarshaller();
+    unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disable external DTDs
+    unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disable external schemas
     return (Comment) unmarshaller.unmarshal(xsr);
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dell4363/WebGoat/security/code-scanning/55](https://github.com/dell4363/WebGoat/security/code-scanning/55)

To fix the issue, we need to explicitly configure the `Unmarshaller` to disable external entity resolution. This can be achieved by setting the `JAXBContext`'s `Unmarshaller` properties to disallow external DTDs and entities. Additionally, we should ensure that the `XMLInputFactory` configuration remains intact to provide an additional layer of protection.

The changes will be made in the `parseXml` method of the `CommentsCache` class. Specifically:
1. Configure the `Unmarshaller` to disable external entity resolution by setting the `javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD` and `javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA` properties to an empty string.
2. Ensure that the `XMLInputFactory` configuration remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
