### PR TITLE
Potential fix for code scanning alert no. 20: Server-side request forgery

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -31,7 +31,9 @@ public class SSRFTask2 implements AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig\\.pro")) {
+    // Define a whitelist of allowed URLs
+    final String allowedUrl = "http://ifconfig.pro";
+    if (url.equals(allowedUrl)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =


### PR DESCRIPTION
Potential fix for [https://github.com/dell4363/WebGoat/security/code-scanning/20](https://github.com/dell4363/WebGoat/security/code-scanning/20)

To fix the SSRF vulnerability, we will implement a whitelist-based validation mechanism. Instead of relying on a regular expression, we will explicitly compare the user-provided URL against a predefined list of allowed URLs. This ensures that only trusted URLs can be accessed, eliminating the risk of SSRF.

Steps to fix:
1. Define a whitelist of allowed URLs (e.g., `http://ifconfig.pro`).
2. Validate the user-provided `url` against this whitelist.
3. Reject any URL that does not match an entry in the whitelist.
4. Update the `furBall` method to incorporate this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
