### PR TITLE
Potential fix for code scanning alert no. 58: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig {
               auth.requestMatchers(HttpMethod.POST, "/files", "/mail", "/requests").permitAll();
               auth.anyRequest().authenticated();
             })
-        .csrf(csrf -> csrf.disable())
+        .csrf(csrf -> csrf)
         .formLogin(
             login ->
                 login


### PR DESCRIPTION
Potential fix for [https://github.com/dell4363/WebGoat/security/code-scanning/58](https://github.com/dell4363/WebGoat/security/code-scanning/58)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. Additionally, CSRF tokens should be properly configured to ensure secure handling of state-changing requests. 

**Steps to fix:**
1. Remove the `csrf.disable()` call from the `filterChain` method.
2. Configure CSRF protection to use default settings, which automatically generate and validate CSRF tokens for state-changing requests.
3. Ensure that the application properly handles CSRF tokens in forms and AJAX requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
