### PR TITLE
Potential fix for code scanning alert no. 57: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
@@ -58,7 +58,7 @@ public class WebSecurityConfig {
               oidc.loginPage("/login");
             })
         .logout(logout -> logout.deleteCookies("JSESSIONID").invalidateHttpSession(true))
-        .csrf(csrf -> csrf.disable())
+        .csrf(csrf -> csrf)
         .headers(headers -> headers.disable())
         .exceptionHandling(
             handling ->


### PR DESCRIPTION
Potential fix for [https://github.com/dell4363/WebGoat/security/code-scanning/57](https://github.com/dell4363/WebGoat/security/code-scanning/57)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. By default, Spring Security enables CSRF protection, so no additional configuration is required to enable it. If there are specific endpoints (e.g., APIs) that need to bypass CSRF protection, they can be explicitly excluded using a `RequestMatcher` or similar configuration. This ensures that CSRF protection is applied to all browser-accessible endpoints while allowing flexibility for non-browser clients.

The changes will involve:
1. Removing the `csrf.disable()` call on line 61.
2. Optionally, configuring CSRF protection to exclude specific endpoints if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
