### PR TITLE
Potential fix for code scanning alert no. 56: Insecure randomness

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/jwt/JWTRefreshEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/JWTRefreshEndpoint.java
@@ -15,6 +15,8 @@ import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.util.ArrayList;
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -73,7 +75,10 @@ public class JWTRefreshEndpoint implements AssignmentEndpoint {
             .signWith(io.jsonwebtoken.SignatureAlgorithm.HS512, JWT_PASSWORD)
             .compact();
     Map<String, Object> tokenJson = new HashMap<>();
-    String refreshToken = RandomStringUtils.randomAlphabetic(20);
+    SecureRandom secureRandom = new SecureRandom();
+    byte[] randomBytes = new byte[20];
+    secureRandom.nextBytes(randomBytes);
+    String refreshToken = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     validRefreshTokens.add(refreshToken);
     tokenJson.put("access_token", token);
     tokenJson.put("refresh_token", refreshToken);


### PR DESCRIPTION
Potential fix for [https://github.com/dell4363/WebGoat/security/code-scanning/56](https://github.com/dell4363/WebGoat/security/code-scanning/56)

To fix the issue, replace the use of `RandomStringUtils.randomAlphabetic(20)` with a cryptographically secure random number generator, such as `SecureRandom`. The `SecureRandom` class in Java provides a cryptographically strong random number generator suitable for generating security-sensitive values like refresh tokens. The fix involves generating a secure random byte array, encoding it as a string (e.g., Base64 or hexadecimal), and using it as the refresh token.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
